### PR TITLE
Add features permalink

### DIFF
--- a/clients/gisquick-web/src/components/AttributesTable.vue
+++ b/clients/gisquick-web/src/components/AttributesTable.vue
@@ -561,7 +561,15 @@ export default {
       })
       const rows = data.features.map(f => attrsNames.map((n, i) => formatters[i](f.properties[n])))
       downloadExcel(header, rows, this.layer.title, this.layer.title)
-    }
+    },
+    getPermalinkParams () {
+      if (this.selectedFeatureIndex !== null) {
+        return {
+          tool: 'hidden-identification',
+          features: this.features[this.selectedFeatureIndex].getId()
+        }
+      }
+    },
   }
 }
 </script>

--- a/clients/gisquick-web/src/components/Identification.vue
+++ b/clients/gisquick-web/src/components/Identification.vue
@@ -359,6 +359,17 @@ export default {
         }
         this.$map.ext.refreshOverlays()
       }
+    },
+    getPermalinkParams () {
+      if (this.selection) {
+        return {
+          feature: this.displayedFeaures[this.selection.featureIndex].getId()
+        }
+      }
+    },
+    loadPermalink (params) {
+      // const { feature: featureId } = params
+      // fetch feature
     }
   }
 }

--- a/clients/gisquick-web/src/components/MapTools.vue
+++ b/clients/gisquick-web/src/components/MapTools.vue
@@ -23,6 +23,7 @@
     <div
       v-if="activeToolObj && activeToolObj.component"
       :is="activeToolObj.component"
+      ref="tool"
       v-bind.sync="activeToolObj.data"
       @close="$store.commit('activeTool', null)"
     />
@@ -69,7 +70,7 @@ export default {
     },
     hiddenIdentificationTool () {
       return {
-        name: 'hidden-identification',
+        name: 'hidden-identification', // idea: try empty string (because of permalink)
         data: this.identificationSettings,
         component: Identification
       }
@@ -152,6 +153,9 @@ export default {
   methods: {
     onClose () {
       this.$store.commit('activeTool', null)
+    },
+    getActiveComponent () {
+      return this.$refs.tool
     }
   }
 }

--- a/clients/gisquick-web/src/components/MapTools.vue
+++ b/clients/gisquick-web/src/components/MapTools.vue
@@ -112,13 +112,18 @@ export default {
           render () {
             return (
               <portal to="bottom-panel">
-                <AttributesTable key="attribute-table" onClose={this.close}/>
+                <AttributesTable key="attribute-table" onClose={this.close} ref="table" />
               </portal>
             )
           },
           methods: {
             close () {
               this.$store.commit('activeTool', null)
+            },
+            getPermalinkParams () {
+              if (this.$refs.table) {
+                return this.$refs.table?.getPermalinkParams?.()
+              }
             }
           }
         }

--- a/clients/gisquick-web/src/components/measure/Measure.vue
+++ b/clients/gisquick-web/src/components/measure/Measure.vue
@@ -146,6 +146,7 @@
 import Vue from 'vue'
 import { mapState } from 'vuex'
 import { getCenter } from 'ol/extent'
+import WKT from 'ol/format/WKT'
 
 import VTabs from '@/ui/Tabs.vue'
 import VTabsHeader from '@/ui/TabsHeader.vue'
@@ -354,6 +355,24 @@ export default {
       // this.location.setVisibility(false)
       // this.distance.setVisibility(false)
       // this.area.setVisibility(false)
+    },
+    getPermalinkParams () {
+      const features = [
+        ...this.location.getFeatures(),
+        ...this.distance.getFeatures(),
+        ...this.area.getFeatures()
+      ]
+      if (features.length) {
+        const precision = this.project.config.units.position_precision
+        const wkt = new WKT().writeFeatures(features, { decimals: precision })
+        return { features: wkt }
+      }
+    },
+    loadPermalink (params) {
+      const { features: wkt } = params
+      const features = new WKT({ splitCollection: true }).readFeatures(wkt)
+      const locations = features.filter(f => f.getGeometry().getType() === 'Point')
+      this.location.setFeatures(locations)
     }
   }
 }

--- a/clients/gisquick-web/src/components/measure/Measure.vue
+++ b/clients/gisquick-web/src/components/measure/Measure.vue
@@ -257,9 +257,9 @@ export default {
   created () {
     if (!this.tools) {
       const tools = Object.freeze({
-        location: LocationMeasure(),
-        distance: DistanceMeasure(),
-        area: AreaMeasure()
+        location: LocationMeasure(this.$map),
+        distance: DistanceMeasure(this.$map),
+        area: AreaMeasure(this.$map)
       })
       observable(tools.location, 'coord1', 'coord2', 'format', 'items')
       observable(tools.distance, 'length', 'items')
@@ -278,7 +278,7 @@ export default {
   },
   mounted () {
     if (activeTool) {
-      activeTool.activate(this.$map)
+      activeTool.activate()
     }
     // this.location.setVisibility(true)
     // this.distance.setVisibility(true)
@@ -296,7 +296,7 @@ export default {
       if (activeTool !== this[tab]) {
         activeTool?.deactivate()
         activeTool = this[tab]
-        activeTool.activate(this.$map)
+        activeTool.activate()
       }
     },
     createUnitsMenu (type) {
@@ -372,7 +372,11 @@ export default {
       const { features: wkt } = params
       const features = new WKT({ splitCollection: true }).readFeatures(wkt)
       const locations = features.filter(f => f.getGeometry().getType() === 'Point')
+      const distances = features.filter(f => f.getGeometry().getType() === 'LineString')
+      const areas = features.filter(f => f.getGeometry().getType() === 'Polygon')
       this.location.setFeatures(locations)
+      this.distance.setFeatures(distances)
+      this.area.setFeatures(areas)
     }
   }
 }

--- a/clients/gisquick-web/src/components/measure/measure.js
+++ b/clients/gisquick-web/src/components/measure/measure.js
@@ -62,7 +62,7 @@ function labelRenderer (pixel, state) {
   ctx.restore()
 }
 
-function createDrawTool (type, style, drawStyle) {
+function createDrawTool (map, type, style, drawStyle) {
   const source = new VectorSource({ features: new Collection([]) })
   const highlightLayer = new VectorLayer({ source, style, className: 'ol-layer measure' })
   const draw = new Draw({ source, type, style: drawStyle })
@@ -88,11 +88,13 @@ function createDrawTool (type, style, drawStyle) {
       this.items.splice(0, this.items.length)
       source.clear()
     },
-    activate (map) {
+    setMap (map) {
       this.map = map
-      map.addInteraction(draw)
-      // user setMap instead of addLayer for required drawing order
+      // used setMap instead of addLayer for required drawing order
       highlightLayer.setMap(map)
+    },
+    activate () {
+      this.map.addInteraction(draw)
     },
     deactivate () {
       if (this.map) {
@@ -103,18 +105,11 @@ function createDrawTool (type, style, drawStyle) {
       highlightLayer.setMap(visible ? this.map : null)
     }
   })
-
-  draw.on('drawstart', evt => {
-    tool.feature = evt.feature
-  })
-  draw.on('drawend', evt => {
-    tool.feature = evt.feature
-  })
-
+  tool.setMap(map)
   return tool
 }
 
-export function LocationMeasure () {
+export function LocationMeasure (map) {
   const normal = simpleStyle({
     radius: 7,
     fill: 'rgb(250, 188, 0)',
@@ -134,7 +129,7 @@ export function LocationMeasure () {
       labelStyle
     ]
   }
-  const base = createDrawTool('Point', styleFn, [])
+  const base = createDrawTool(map, 'Point', styleFn, [])
 
   function createItem (id, feature) {
     const coords = feature.getGeometry().getCoordinates()
@@ -177,7 +172,7 @@ export function LocationMeasure () {
   })
 }
 
-export function DistanceMeasure () {
+export function DistanceMeasure (map) {
   const normal = [
     new Style({
       stroke: new Stroke({
@@ -235,19 +230,20 @@ export function DistanceMeasure () {
       })
     ]
   }
-  const base = createDrawTool('LineString', styleFn, styleFn)
+  const base = createDrawTool(map, 'LineString', styleFn, styleFn)
 
-  function measure () {
+  function measure (feature) {
+    const data = feature.get('data')
     const projection = base.map.getView().getProjection()
-    const geom = base.feature.getGeometry()
+    const geom = feature.getGeometry()
 
     const lastSegmentIndex = geom.getCoordinates().length - 2
     let i = 0
     geom?.forEachSegment?.((start, end) => {
-      if (!base.current.segments[i] || i === lastSegmentIndex) {
+      if (!data.segments[i] || i === lastSegmentIndex) {
         const segment = new LineString([start, end])
         const length = projection.isGlobal() ? getLength(segment, { projection }) : segment.getLength()
-        base.current.segments[i] = {
+        data.segments[i] = {
           length,
           geom: segment,
           label: base.format.length(length)
@@ -257,9 +253,9 @@ export function DistanceMeasure () {
     })
 
     const length = projection.isGlobal() ? getLength(geom, { projection }) : geom.getLength()
-    base.current._length = length
-    base.current.length = base.format.length(length)
-    base.feature.set('label', base.current.length)
+    data._length = length
+    data.length = base.format.length(length)
+    feature.set('label', data.length)
   }
 
   let moveListener, clickListener
@@ -269,22 +265,34 @@ export function DistanceMeasure () {
       length: 0,
       segments: []
     }
-
     base.items.push(base.current)
-    measure()
-    base.feature.set('data', base.current)
-
-    moveListener = base.map.on('pointermove', throttle(() => measure(), 30))
+    evt.feature.set('data', base.current)
+    measure(evt.feature)
+    moveListener = base.map.on('pointermove', throttle(() => measure(evt.feature), 30))
   })
 
-  base.draw.on('drawend', () => {
-    base.feature.set('id', base.current.id)
+  base.draw.on('drawend', evt => {
+    evt.feature.set('id', base.current.id)
     unByKey(moveListener)
     unByKey(clickListener)
   })
 
   return Object.assign(base, {
     current: null,
+    setFeatures (features) {
+      base.items = features.map((feature, i) => {
+        const data = {
+          id: i,
+          length: 0,
+          segments: []
+        }
+        feature.set('data', data)
+        feature.set('id', data.id)
+        measure(feature)
+        return data
+      })
+      base.source.addFeatures(features)
+    },
     setFormat (format) {
       this.format = format
       if (this.items.length) {
@@ -300,7 +308,7 @@ export function DistanceMeasure () {
   })
 }
 
-export function AreaMeasure () {
+export function AreaMeasure (map) {
   const normal = [
     new Style({
       stroke: new Stroke({
@@ -369,19 +377,20 @@ export function AreaMeasure () {
       })
     ]
   }
-  const base = createDrawTool('Polygon', styleFn, styleFn)
+  const base = createDrawTool(map, 'Polygon', styleFn, styleFn)
 
-  function measure () {
+  function measure (feature) {
+    const data = feature.get('data')
     const projection = base.map.getView().getProjection()
-    const geom = base.feature.getGeometry()
+    const geom = feature.getGeometry()
     const pointsCount = geom.getLinearRing(0).getCoordinates().length
     if (pointsCount > 3) {
       if (projection.isGlobal()) {
-        base.current._area = getArea(geom, { projection })
-        base.current._perimeter = getLength(geom, { projection })
+        data._area = getArea(geom, { projection })
+        data._perimeter = getLength(geom, { projection })
       } else {
-        base.current._area = geom.getArea()
-        base.current._perimeter = linearRingLength(geom.getFlatCoordinates(), 0, pointsCount * 2, 2)
+        data._area = geom.getArea()
+        data._perimeter = linearRingLength(geom.getFlatCoordinates(), 0, pointsCount * 2, 2)
       }
     }
 
@@ -389,10 +398,10 @@ export function AreaMeasure () {
     const lastStableIndex = line.getCoordinates().length - 4
     let i = 0
     line.forEachSegment?.((start, end) => {
-      if (!base.current.segments[i] || i > lastStableIndex) {
+      if (!data.segments[i] || i > lastStableIndex) {
         const segment = new LineString([start, end])
         const length = projection.isGlobal() ? getLength(segment, { projection }) : segment.getLength()
-        base.current.segments[i] = {
+        data.segments[i] = {
           length,
           geom: segment,
           label: base.format.length(length)
@@ -401,9 +410,9 @@ export function AreaMeasure () {
       i++
     })
 
-    base.current.area = base.format.area(base.current._area ?? 0)
-    base.current.perimeter = base.format.length(base.current._perimeter ?? 0)
-    base.feature.set('label', base.current.area)
+    data.area = base.format.area(data._area ?? 0)
+    data.perimeter = base.format.length(data._perimeter ?? 0)
+    feature.set('label', data.area)
   }
 
   let moveListener
@@ -415,18 +424,32 @@ export function AreaMeasure () {
       segments: []
     }
     base.items.push(base.current)
-    base.feature.set('data', base.current)
-    moveListener = base.map.on('pointermove', throttle(() => measure(), 30))
+    evt.feature.set('data', base.current)
+    moveListener = base.map.on('pointermove', throttle(() => measure(evt.feature), 30))
   })
 
   base.draw.on('drawend', evt => {
-    base.feature.set('id', base.current.id)
-    base.feature = null
+    evt.feature.set('id', base.current.id)
     unByKey(moveListener)
   })
 
   return Object.assign(base, {
     current: null,
+    setFeatures (features) {
+      base.items = features.map((feature, i) => {
+        const data = {
+          id: i,
+          area: 0,
+          perimeter: 0,
+          segments: []
+        }
+        feature.set('data', data)
+        feature.set('id', data.id)
+        measure(feature)
+        return data
+      })
+      base.source.addFeatures(features)
+    },
     setFormat (format) {
       this.format = format
       if (this.items.length) {


### PR DESCRIPTION
This PR adds permalinks for features.

- All features in QGIS Server WFS have its own unique feature id shaped `${layer.name}.${feature.id}`.
- Generated permalink will have new query param `features` including comma separated list of feature ids.
- Part of identification state has been moved to vuex state to read this state from outside `Identification` Vue component.