### PR TITLE
Disable "zoom to feature" buttons for features with no geometry

### DIFF
--- a/clients/gisquick-web/src/components/AttributesTable.vue
+++ b/clients/gisquick-web/src/components/AttributesTable.vue
@@ -44,9 +44,13 @@
       </template>
       <template v-slot:cell(actions)="{ row }">
         <div class="f-row-ac">
-          <v-btn class="icon flat m-0" @click="zoomToFeature(features[row])">
+          <v-btn v-if="features[row].getGeometry()" class="icon flat m-0" @click="zoomToFeature(features[row])">
             <v-icon name="zoom-to"/>
           </v-btn>
+          <v-btn v-else class="icon flat m-0" disabled :title="tr.NoGeometry">
+            <v-icon name="zoom-to"/>
+          </v-btn>
+
           <v-btn class="icon flat my-0 mr-0" @click="showInfoPanel = true">
             <v-icon name="circle-i-outline"/>
           </v-btn>
@@ -316,6 +320,7 @@ export default {
       return {
         FilterVisibleLabel: this.$gettext('Filter to visible area'),
         PageSize: this.$gettext('Page size'),
+        NoGeometry: this.$gettext('No geometry'),
         link: this.$gettext('link')
       }
     },

--- a/clients/gisquick-web/src/components/InfoPanel.vue
+++ b/clients/gisquick-web/src/components/InfoPanel.vue
@@ -55,7 +55,7 @@
       </scroll-area>
 
       <div class="toolbar tools dark f-row-ac">
-        <v-btn class="icon flat" @click="zoomToFeature">
+        <v-btn class="icon flat" @click="zoomToFeature" :disabled="!this.feature.getGeometry()">
           <v-icon name="zoom-to"/>
         </v-btn>
         <v-btn


### PR DESCRIPTION
With this change it is clear which features in AttributeTable and InfoPanel do not have geometry.

![Snímek obrazovky 2023-12-03 v 20 24 14](https://github.com/gisquick/gisquick/assets/348276/0dacd106-ded0-4ad1-a390-02102bcf7477)
