### PR TITLE
Fix geometry projection for new features

### DIFF
--- a/clients/gisquick-web/src/components/feature-editor/NewFeatureEditor.vue
+++ b/clients/gisquick-web/src/components/feature-editor/NewFeatureEditor.vue
@@ -154,7 +154,14 @@ export default {
       }
       const f = this.createFeature(resolvedFields)
       const geom = this.references.geometryEditor.getGeometry()
-      f.setGeometry(geom)
+      // Transform to projection of project
+      let newGeom = geom
+      const mapProjection = this.$map.getView().getProjection().getCode()
+      if (newGeom && mapProjection !== this.layer.projection) {
+        newGeom = newGeom.clone()
+        newGeom.transform(mapProjection, this.layer.projection)
+      }
+      f.setGeometry(newGeom)
 
       this.statusController.set('loading', 1000)
       wfsTransaction(this.project.config.ows_url, this.layer.name, { inserts: [f] })


### PR DESCRIPTION
When new feature is added, the geometry has wrong projection. Looks like bug, because it works in regular `FeatureEditor`.

This PR fixes geometry projection for new features.